### PR TITLE
Update

### DIFF
--- a/force-app/main/default/classes/CaseTriggerHandler.cls
+++ b/force-app/main/default/classes/CaseTriggerHandler.cls
@@ -94,6 +94,7 @@ public without sharing class CaseTriggerHandler {
         }
 
         CaseTriggerHelper.historialCaso(newCaseList, oldCaseMap);
+        CaseTriggerHelper.UpdateFields(newCaseList, oldCaseMap);
         
         if(executeFlag) {
             CaseTriggerHelper.solventarPregunta(newCaseList, oldCaseMap);

--- a/force-app/main/default/classes/CaseTriggerHelper.cls
+++ b/force-app/main/default/classes/CaseTriggerHelper.cls
@@ -16,6 +16,7 @@
 * 2024-04-26   Intellect Systems             Modify method called: validacionProducto, to validate products related to account.  
 * 2024-05-02   Intellect Systems             Se añade validación en el método: validacionUser, se incluye perfil: Servicio al Cliente.
 * 2027-07-24   Intellect Systems             Se remueve bloqué de código del método: validacionFechaEntrega.
+* 2024-09-24   Intellect Systems             Se añade metodo para actualizacion de campos post actualizacion.
 **************************************************************************************************************
 */
 
@@ -338,6 +339,21 @@ public without sharing class CaseTriggerHelper {
         if(!updateCaseList.isEmpty()) {
             update updateCaseList;
         }
+    }
+    
+    public static void UpdateFields(List<Case> newCaseList, Map<Id, Case> oldCaseMap) {
+         list<Case> updateCaseList = new list<Case>();
+        for(Case item: newCaseList) {
+            if(item.FS_AceptaRespuesta__c == 'No'){
+                Case record = new Case(Id = item.Id);
+                record.FS_AceptaRespuesta__c = '';
+                updateCaseList.add(record);
+            }
+        }
+        if(!updateCaseList.isEmpty()) {
+            update updateCaseList;
+        }
+        
     }
     
     public static void validacionAprobacionSolucion(List<Case> newCaseList, Map<Id, Case> oldCaseMap){

--- a/force-app/main/default/classes/CaseTriggerHelperPMPS.cls
+++ b/force-app/main/default/classes/CaseTriggerHelperPMPS.cls
@@ -133,7 +133,7 @@ public with sharing class CaseTriggerHelperPMPS {
             }
             if(record.FS_AceptaRespuesta__c == 'No' && record.Status == 'Validación de Respuesta (Cliente)' && record.FS_AceptaRespuesta__c != caso.FS_AceptaRespuesta__c) {
                 record.Status = 'En Desarrollo'; 
-                record.FS_AceptaRespuesta__c = ''; 
+                //record.FS_AceptaRespuesta__c = ''; 
                 CaseTriggerHelper.crearHistorialAprobaciones(record);
                 casesNew.add(record);
                 casesOld.add(caso);

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -3,6 +3,7 @@
 	<types>
 		<members>CaseTriggerHandler</members>
 		<members>CaseTriggerHelper</members>
+		<members>CaseTriggerHelperPMPS</members>
 		<members>CaseTriggerHelper_Test</members>
 		<members>ContactTriggerHandler</members>
 		<members>ContactTriggerHelper</members>


### PR DESCRIPTION
* Se añaden ajustes al campo **Acepta Respuesta** API: **FS_AceptaRespuesta__c**. al momento de agregar la opción "**No**" se actualice a null post actualización del caso para que quede registrado dentro del historial por respuestas del cliente dentro de la comunidad. 